### PR TITLE
Allow interference() to run silently

### DIFF
--- a/R/interference.R
+++ b/R/interference.R
@@ -106,6 +106,7 @@ interference <- function(formula,
                                                           variance_estimation = 'robust'),
                          conf.level = 0.95,
                          rescale.factor = 1,   
+                         runSilent=F, #Enables/disables printing of function progress #BB 2015-06-23
                          ...)
 {
   ## Necessary bits ##
@@ -201,12 +202,13 @@ interference <- function(formula,
                             allocations          = allocations,
                             fixed.effects        = fixed.effects, 
                             random.effects       = random.effects,
+                            runSilent               = runSilent,  #BB 2015-06-23
                             Y = Y, X = X, A = A, B = B, G = G))
   
     ipw <- do.call(ipw_interference, args = ipw_args)
     out <- append(out, ipw)
     
-    print('Computing effect estimates...')
+    if(runSilent!=T){print('Computing effect estimates...')} #BB 2015-06-23
     
     estimate_args <- list(obj = ipw,
                           variance_estimation = causal_estimation_options$variance_estimation,
@@ -254,6 +256,6 @@ interference <- function(formula,
   
   class(out) <- "interference"
   
-  print('Interference complete')
+  if(runSilent!=T){print('Interference complete')} #BB 2015-06-23
   return(out)
 }

--- a/R/interference.R
+++ b/R/interference.R
@@ -104,9 +104,9 @@ interference <- function(formula,
                          causal_estimation_method = 'ipw',
                          causal_estimation_options = list(set_NA_to_0 = TRUE, 
                                                           variance_estimation = 'robust'),
-                         conf.level = 0.95,
+                         conf.level     = 0.95,
                          rescale.factor = 1,   
-                         runSilent=F, #Enables/disables printing of function progress #BB 2015-06-23
+                         runSilent      = F, #Enables/disables printing of function progress #BB 2015-06-23
                          ...)
 {
   ## Necessary bits ##
@@ -202,13 +202,13 @@ interference <- function(formula,
                             allocations          = allocations,
                             fixed.effects        = fixed.effects, 
                             random.effects       = random.effects,
-                            runSilent               = runSilent,  #BB 2015-06-23
+                            runSilent            = runSilent,  #BB 2015-06-23
                             Y = Y, X = X, A = A, B = B, G = G))
   
     ipw <- do.call(ipw_interference, args = ipw_args)
     out <- append(out, ipw)
     
-    if(runSilent!=T){print('Computing effect estimates...')} #BB 2015-06-23
+    if(runSilent != T){print('Computing effect estimates...')} #BB 2015-06-23
     
     estimate_args <- list(obj = ipw,
                           variance_estimation = causal_estimation_options$variance_estimation,
@@ -256,6 +256,6 @@ interference <- function(formula,
   
   class(out) <- "interference"
   
-  if(runSilent!=T){print('Interference complete')} #BB 2015-06-23
+  if(runSilent != T){print('Interference complete')} #BB 2015-06-23
   return(out)
 }

--- a/R/ipw_interference.R
+++ b/R/ipw_interference.R
@@ -32,7 +32,7 @@ ipw_interference <- function(propensity_integrand,
                              random.effects,
                              variance_estimation,
                              set_NA_to_0 = TRUE,
-                             runSilent=F, #BB 2015-06-23 pass runSilent in from interference()
+                             runSilent   = F, #BB 2015-06-23 pass runSilent in from interference()
                              ...)
 {
   dots <- list(...)
@@ -50,9 +50,9 @@ ipw_interference <- function(propensity_integrand,
                         list(integrand = propensity_integrand, 
                              allocations = allocations, 
                              X = X, A = A, G = G,
-                             fixed.effects = fixed.effects,
+                             fixed.effects  = fixed.effects,
                              random.effects = random.effects,
-                             runSilent=runSilent #BB 2015-06-23
+                             runSilent      = runSilent #BB 2015-06-23
                              ))
   #### Prepare output ####
   out <- list()  
@@ -87,7 +87,7 @@ ipw_interference <- function(propensity_integrand,
                                      A = B, # Use B for treatment in scores
                                      fixed.effects  = fixed.effects,
                                      random.effects = random.effects,
-                                     runSilent         = runSilent #BB 2015-06-23
+                                     runSilent      = runSilent #BB 2015-06-23
                                      ))
     
     # set randomization scheme to 1 for scores for logit_integrand

--- a/R/ipw_interference.R
+++ b/R/ipw_interference.R
@@ -32,6 +32,7 @@ ipw_interference <- function(propensity_integrand,
                              random.effects,
                              variance_estimation,
                              set_NA_to_0 = TRUE,
+                             runSilent=F, #BB 2015-06-23 pass runSilent in from interference()
                              ...)
 {
   dots <- list(...)
@@ -50,7 +51,9 @@ ipw_interference <- function(propensity_integrand,
                              allocations = allocations, 
                              X = X, A = A, G = G,
                              fixed.effects = fixed.effects,
-                             random.effects = random.effects))
+                             random.effects = random.effects,
+                             runSilent=runSilent #BB 2015-06-23
+                             ))
   #### Prepare output ####
   out <- list()  
 
@@ -82,8 +85,10 @@ ipw_interference <- function(propensity_integrand,
     score_args <- append(sargs, list(integrand = loglihood_integrand,
                                      X = X, G = G, 
                                      A = B, # Use B for treatment in scores
-                                     fixed.effects = fixed.effects,
-                                     random.effects = random.effects))
+                                     fixed.effects  = fixed.effects,
+                                     random.effects = random.effects,
+                                     runSilent         = runSilent #BB 2015-06-23
+                                     ))
     
     # set randomization scheme to 1 for scores for logit_integrand
     score_args$randomization <- 1

--- a/R/score_matrix.R
+++ b/R/score_matrix.R
@@ -18,6 +18,7 @@ score_matrix <- function(integrand,
                          X, A, G, 
                          fixed.effects,
                          random.effects,
+                         runSilent=F, #BB 2015-06-23 #Pass in from ipw_interference()
                          ...)
 {
   ## Warnings ##
@@ -37,7 +38,7 @@ score_matrix <- function(integrand,
                      get_args(integrate, dots))
   fargs <- append(int.args, get_args(numDeriv::grad, dots))
   
-  print("Calculating matrix of scores...")
+  if(runSilent!=T){print("Calculating matrix of scores...")} #BB 2015-06-23
   s.list <- by(XX, INDICES = G, simplify = TRUE, 
                FUN = function(xx) {
                args <- append(fargs, 

--- a/R/score_matrix.R
+++ b/R/score_matrix.R
@@ -18,7 +18,7 @@ score_matrix <- function(integrand,
                          X, A, G, 
                          fixed.effects,
                          random.effects,
-                         runSilent=F, #BB 2015-06-23 #Pass in from ipw_interference()
+                         runSilent = F, #BB 2015-06-23 #Pass in from ipw_interference()
                          ...)
 {
   ## Warnings ##
@@ -38,7 +38,7 @@ score_matrix <- function(integrand,
                      get_args(integrate, dots))
   fargs <- append(int.args, get_args(numDeriv::grad, dots))
   
-  if(runSilent!=T){print("Calculating matrix of scores...")} #BB 2015-06-23
+  if(runSilent != T){print("Calculating matrix of scores...")} #BB 2015-06-23
   s.list <- by(XX, INDICES = G, simplify = TRUE, 
                FUN = function(xx) {
                args <- append(fargs, 

--- a/R/wght_deriv_array.R
+++ b/R/wght_deriv_array.R
@@ -24,7 +24,7 @@ wght_deriv_array <- function(integrand,
                              X, A, G,
                              fixed.effects,
                              random.effects,
-                             runSilent=F, #BB 2015-06-23 #pass in from ipw_interference()
+                             runSilent = F, #BB 2015-06-23 #pass in from ipw_interference()
                              ...)
 {
   ## Gather necessary bits ##
@@ -41,7 +41,7 @@ wght_deriv_array <- function(integrand,
   ## Warnings ##
 
   ## Compute weight (derivative) for each group, parameter, and alpha level ##
-  if(runSilent!=T){print('Calculating array of IP weight derivatives...')} #BB 2015-06-23
+  if(runSilent != T){print('Calculating array of IP weight derivatives...')} #BB 2015-06-23
   
   w.list <- lapply(aa, function(allocation){
     w <- by(XX, INDICES = G, simplify = TRUE, 

--- a/R/wght_deriv_array.R
+++ b/R/wght_deriv_array.R
@@ -24,6 +24,7 @@ wght_deriv_array <- function(integrand,
                              X, A, G,
                              fixed.effects,
                              random.effects,
+                             runSilent=F, #BB 2015-06-23 #pass in from ipw_interference()
                              ...)
 {
   ## Gather necessary bits ##
@@ -40,7 +41,7 @@ wght_deriv_array <- function(integrand,
   ## Warnings ##
 
   ## Compute weight (derivative) for each group, parameter, and alpha level ##
-  print('Calculating array of IP weight derivatives...')
+  if(runSilent!=T){print('Calculating array of IP weight derivatives...')} #BB 2015-06-23
   
   w.list <- lapply(aa, function(allocation){
     w <- by(XX, INDICES = G, simplify = TRUE, 

--- a/R/wght_matrix.R
+++ b/R/wght_matrix.R
@@ -25,7 +25,7 @@ wght_matrix <- function(integrand,
                         X, A, G,
                         fixed.effects,
                         random.effects = NULL,
-                        runSilent=F, #pass runSilent in from interference higher function  ipw_interference #BB 2015-06-23 
+                        runSilent = F, #pass runSilent in from interference higher function  ipw_interference #BB 2015-06-23 
                         ...)
 {
   ## Gather necessary bits ##
@@ -35,7 +35,7 @@ wght_matrix <- function(integrand,
   gg <- sort(unique(G))
   
   ## Compute weight for each group and allocation level ##
-  if(runSilent!=T){print('Calculating matrix of IP weights...')} #BB 2015-06-23
+  if(runSilent != T){print('Calculating matrix of IP weights...')} #BB 2015-06-23
   
   w.list <- lapply(aa, function(allocation){
     w <- by(cbind(X, A), INDICES = G, simplify = FALSE, 

--- a/R/wght_matrix.R
+++ b/R/wght_matrix.R
@@ -25,6 +25,7 @@ wght_matrix <- function(integrand,
                         X, A, G,
                         fixed.effects,
                         random.effects = NULL,
+                        runSilent=F, #pass runSilent in from interference higher function  ipw_interference #BB 2015-06-23 
                         ...)
 {
   ## Gather necessary bits ##
@@ -34,7 +35,7 @@ wght_matrix <- function(integrand,
   gg <- sort(unique(G))
   
   ## Compute weight for each group and allocation level ##
-  print('Calculating matrix of IP weights...')
+  if(runSilent!=T){print('Calculating matrix of IP weights...')} #BB 2015-06-23
   
   w.list <- lapply(aa, function(allocation){
     w <- by(cbind(X, A), INDICES = G, simplify = FALSE, 


### PR DESCRIPTION
Changes add boolean argument runSIlent to interference() and the four sub-functions that print the following output when interference() is run:

[1] "Calculating matrix of IP weights..."
[1] "Calculating array of IP weight derivatives..."
[1] "Calculating matrix of scores..."
[1] "Computing effect estimates..."
[1] "Interference complete"

isSilent defaults to FALSE. When isSilent is set to TRUE then the above output is not printed.

