### PR TITLE
I added the ability to automatically get the (inverse) link function from model_options

### DIFF
--- a/R/generalized_integrand.R
+++ b/R/generalized_integrand.R
@@ -11,7 +11,7 @@ generalized_integrand <- function(b, X, A,
                             reff_dist = list(
                               dens = stats::dnorm,
                               mean=0),
-                            link_fun)
+                            inv_link_fun)
 {
   p  <- length(fixed.effects)
   re <- random.effects[1]
@@ -36,8 +36,8 @@ generalized_integrand <- function(b, X, A,
     stop("reff_dist needs to provide a density and a mean parameter for generalized_integrand")
   }
   
-  if(is.null(link_fun)){
-    stop("Must specify link_fun in generalized_integrand")
+  if(is.null(inv_link_fun)){
+    stop("Must specify inv_link_fun in generalized_integrand")
   }
   
   ## For taking derivative w.r.t. a parameter ##
@@ -48,9 +48,9 @@ generalized_integrand <- function(b, X, A,
   
   ## Calculations ## 
   if(is.null(re) || re <= 0){
-    pr.b <- randomization * (link_fun(X %*% params[1:p]))
+    pr.b <- randomization * (inv_link_fun(X %*% params[1:p]))
   } else {
-    pr.b <- randomization * (link_fun(drop(outer(X %*% params[1:p], b, '+'))))
+    pr.b <- randomization * (inv_link_fun(drop(outer(X %*% params[1:p], b, '+'))))
   }
   if(integrate.allocation == FALSE){
     hh <- dbinom(A, 1, pr.b)

--- a/R/interference.R
+++ b/R/interference.R
@@ -178,11 +178,17 @@ interference <- function(formula,
       stop('At least one random effect was estimated as 0. This will lead to a
            non-invertible matrix if using robust variance estimation.')
     }
+    ##use link_obj$linkinv( eta ) to get value of E(Y)=mu=linkinv(eta), as link(E(Y))=eta 
+    link_obj <- stats::make.link((model_options$family)$link)
+    
   } else if(model_method == "glm"){
     propensity_model <- do.call("glm", args = estimation_args)
     fixed.effects  <- coef(propensity_model)
     random.effects <- NULL
     X <- model.matrix(propensity_model)
+    ##use link_obj$linkinv( eta ) to get value of E(Y)=mu=linkinv(eta), as link(E(Y))=eta 
+    link_obj <- stats::make.link((model_options$family)$link)
+    
   } else if(model_method == "oracle"){
     fixed.effects  <- model_options[[1]]
     random.effects <- model_options[[2]]
@@ -207,6 +213,7 @@ interference <- function(formula,
                             fixed.effects        = fixed.effects, 
                             random.effects       = random.effects,
                             runSilent            = runSilent,  #BB 2015-06-23
+                            inv_link_fun         = link_obj$linkinv, ## BB 2016-03-20 
                             Y = Y, X = X, A = A, B = B, G = G))
   
     ipw <- do.call(ipw_interference, args = ipw_args)


### PR DESCRIPTION
I added the ability to automatically get the (inverse) link function
using stats::make_link(). This takes the link function name (a character
string) specified in model_options and feeds it as an argument to
make_link(), which should return an object called link_obj of class
"link-glm".

This object link_obj contains the object link_obj$linkinv of type
"function" which can be used with generalized_integrand() to obtain:
E(Y) = link_obj$linkinv( eta ) where eta is equal to the sum of
random.effects plus the product of model.matrix and fixed.effects.

These changes have not yet been fully implemented; they are simply
passed into the dots() function of ipw_interference. No further efforts
have been made.